### PR TITLE
Add environment Docker image use instructions

### DIFF
--- a/notebooks/Setup.ipynb
+++ b/notebooks/Setup.ipynb
@@ -69,7 +69,7 @@
     "```\n",
     "conda install -c conda-forge libiconv jupyter_contrib_nbextensions\n",
     "conda install -c astropy emcee astroml\n",
-    "pip install wpca autograd tensorflow edward\n",
+    "pip install wpca autograd tensorflow tensorflow-probability\n",
     "```\n",
     "You might see something like\n",
     "```\n",
@@ -333,7 +333,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -347,7 +347,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.5"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/Setup.ipynb
+++ b/notebooks/Setup.ipynb
@@ -61,7 +61,7 @@
     "conda create -n DAMLA python=3.6 pip ipython jupyter numpy scipy pandas\n",
     "   matplotlib seaborn scikit-learn hdf5 pytables pillow\n",
     "```\n",
-    "Activate the new environment using (this should add \"(MLS)\" to your command prompt, as a reminder of your current environment):\n",
+    "Activate the new environment using (this should add \"(DAMLA)\" to your command prompt, as a reminder of your current environment):\n",
     "```\n",
     "source activate DAMLA\n",
     "```\n",
@@ -132,7 +132,7 @@
     "cd notebooks\n",
     "jupyter notebook\n",
     "```\n",
-    "Note that `[[syllabus]]` is a reminder that you must be in your `syllabus` directory before typing the following commands.  If you are unsure about this, refer to the [pwd](http://www.linfo.org/pwd.html) and [cd](http://www.linfo.org/cd.html) commands.\n",
+    "Note that `[[syllabus]]` is a reminder that you must be in your `syllabus` directory before typing the following commands.  If you are unsure about this, refer to the [`pwd`](http://www.linfo.org/pwd.html) and [`cd`](http://www.linfo.org/cd.html) commands.\n",
     "\n",
     "**Windows users:** Wherever you see `source activate DAMLA`, use `activate DAMLA` instead.  Details [here](https://conda.io/docs/user-guide/tasks/manage-environments.html#activating-an-environment).\n",
     "\n",
@@ -200,11 +200,140 @@
     "pip install . --upgrade\n",
     "```"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using the environment Docker image"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If there is a problem that keeps you from being able to easily install the Conda environment on your local machine you can use the environment on the [provided Docker image](https://github.com/illinois-mla/DAMLA-env). The Docker image is meant to provide the compute environment, but not to be used as an area to store your work, so you should still clone the repo down to your local machine."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Installation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To install Docker Community Edition on your Linux, Mac, or Windows machine follow the [instructions in the Docker docs](https://docs.docker.com/install/)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Running the environment\n",
+    "\n",
+    "To use the Docker image first [pull](https://docs.docker.com/engine/reference/commandline/pull/) it down from Docker Hub\n",
+    "\n",
+    "`\n",
+    "docker pull illinoismla/damla-env\n",
+    "`\n",
+    "\n",
+    "If you want anything you do in the container to safely persist then you should bindmount your local machine's file system to the container as a [volume](https://docs.docker.com/storage/volumes/). So [run](https://docs.docker.com/engine/reference/commandline/run/) the image in a container while [exposing](https://docs.docker.com/engine/reference/run/#expose-incoming-ports) the container's internal port `8888` with the `-p` flag (this is necessary for Jupyter to be able to talk to the `localhost`) and bindmount the directory of the course Git repo on your local machine\n",
+    "\n",
+    "`\n",
+    "docker run --rm -it -v <path to the repo goes here>:/root/data -p 8888:8888 illinoismla/damla-env:latest /bin/bash\n",
+    "`\n",
+    "\n",
+    "Once inside the container activate the DAMLA Conda environment\n",
+    "\n",
+    "`\n",
+    "conda activate DAMLA\n",
+    "`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Verifying the setup\n",
+    "\n",
+    "To verify that things are working as expected, launch a Jupyter notebook server and test basic imports (the \"Hello World\" of data analysis).\n",
+    "\n",
+    "Inside the running Docker container with the `DAMLA` environment activated navigate to `/root/data` (this is an arbitrary path that we chose when running the Docker image &mdash; you can make this whatever you want). If you `ls` you will see that you are actually inside your Git repo on your local machine.\n",
+    "\n",
+    "Then launch the Jupyter server\n",
+    "\n",
+    "`\n",
+    "jupyter notebook\n",
+    "`\n",
+    "\n",
+    "which will cause a login URL with a token to be printed to your terminal\n",
+    "\n",
+    "`\n",
+    "http://localhost:8888/?token=<token>\n",
+    "`\n",
+    "\n",
+    "Click on the URL, and copy and paste it into your web browser on your local machine. This should then display the Jupyter server in your web browser.\n",
+    "\n",
+    "Create a new Jupyter notebook (select from the \"New\" drop down menu on the upper right) and then when the notebook opens import NumPy and run a simple test\n",
+    "\n",
+    "```\n",
+    "import numpy as np\n",
+    "np.arange(0, 10, 0.5)\n",
+    "```\n",
+    "`\n",
+    "array([0. , 0.5, 1. , 1.5, 2. , 2.5, 3. , 3.5, 4. , 4.5, 5. , 5.5, 6. ,\n",
+    "       6.5, 7. , 7.5, 8. , 8.5, 9. , 9.5])\n",
+    "`\n",
+    "\n",
+    "If you now save the notebook and in a different terminal window on your local machine you navigate to the Git repo directory you will now see that **on your local machine** there is the Jupyter notebook. If you shutdown and exit the Jupter server, and exit the Docker container you will see that though the environment has exited and been [cleaned up](https://docs.docker.com/engine/reference/run/#clean-up---rm) the notebook has persisted."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://asciinema.org/a/198304\"><img src=\"https://asciinema.org/a/198304.png\" width=\"836\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Container persistance\n",
+    "\n",
+    "There should be no need to reuse the same container, as the thing you care about is the data and files you're writing which should exist on your local machine (nicely versioned with Git). However, if in the event you do want the container to persist between uses you can remove the [`--rm` flag](https://docs.docker.com/engine/reference/run/#clean-up---rm) from the `docker run` command to keep the container from being [removed](https://docs.docker.com/engine/reference/commandline/rm/). In this situation it is a good idea to also name the container with the [`--name` flag](https://docs.docker.com/engine/reference/run/#name---name)\n",
+    "\n",
+    "`\n",
+    "docker run --name DAMLA-env-container -it -v <path to the repo goes here>:/root/data -p 8888:8888 illinoismla/damla-env:latest /bin/bash\n",
+    "`\n",
+    "\n",
+    "After you exit the container if you [list](https://docs.docker.com/engine/reference/commandline/ps/) the Docker containers on your local machine\n",
+    "\n",
+    "`\n",
+    "docker ps -a\n",
+    "`\n",
+    "\n",
+    "you will see your exited container. To resume using _that specific container_  [start](https://docs.docker.com/engine/reference/commandline/start/) it again \n",
+    "\n",
+    "`\n",
+    "docker start DAMLA-env-container\n",
+    "`\n",
+    "\n",
+    "and then [attach](https://docs.docker.com/engine/reference/commandline/attach/) it to your shell\n",
+    "\n",
+    "`\n",
+    "docker attach DAMLA-env-container\n",
+    "`"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python3"
   },
@@ -218,7 +347,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.5.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Adds use instructions for the [DAMLA environment Docker image](https://github.com/illinois-mla/DAMLA-env) and updates the recommend environment to use [TensorFlow probability](https://github.com/tensorflow/probability) instead of Edward. Edward is no longer actively maintained and all development has moved to [Edward2](https://github.com/tensorflow/probability/tree/master/tensorflow_probability/python/edward2) in `tfp`.

The new Setup instructions can be previewed rendered [here](https://github.com/illinois-mla/syllabus/blob/revise/add-Docker-instructions/notebooks/Setup.ipynb)