### PR TITLE
Add setuptools-git to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,6 @@ setup(
     author_email='msn@illinois.edu',
     license='BSD3',
     packages=['mls'],
-    install_requires=[ ],
+    install_requires=['setuptools-git'],
     include_package_data=True,
     zip_safe=False)


### PR DESCRIPTION
This is needed to properly setup the [mls module](https://github.com/illinois-mla/syllabus/tree/master/mls) from the Git repo, especially during a sparse checkout